### PR TITLE
Implement model that utilises experience replay and fixed target approxmation

### DIFF
--- a/config/model.json
+++ b/config/model.json
@@ -1,4 +1,4 @@
 {
-  "model_name": "deepQN_v2",
+  "model_name": "deepQN_v3",
   "experiment_id": "exp_1"
 }

--- a/config/train.json
+++ b/config/train.json
@@ -1,7 +1,7 @@
 {
   "checkpoint_frequency": 100,
   "overwrite_experiment_id": true,
-  "min_buffer_size": 64,
-  "max_episodes": 1000,
+  "min_buffer_size": 5000,
+  "max_episodes": 5000,
   "gamma": 0.9
 }

--- a/model/deepQN_v3/exp_0/params.json
+++ b/model/deepQN_v3/exp_0/params.json
@@ -1,0 +1,11 @@
+{
+  "network": {
+    "fc1": 64,
+    "fc2": 32
+  },
+  "init_learning_rate": 1e-3,
+  "epsilon_root_factor": 4,
+  "random_seed": 1234,
+  "batch_size": 64,
+  "tau": 1e-2
+}

--- a/model/deepQN_v3/exp_1/params.json
+++ b/model/deepQN_v3/exp_1/params.json
@@ -1,0 +1,11 @@
+{
+  "network": {
+    "fc1": 64,
+    "fc2": 32
+  },
+  "init_learning_rate": 1e-3,
+  "epsilon_root_factor": 3,
+  "random_seed": 1234,
+  "batch_size": 64,
+  "tau": 5e-2
+}

--- a/model/deepQN_v3/model.py
+++ b/model/deepQN_v3/model.py
@@ -1,0 +1,31 @@
+"""
+DQN with experience replay and fixed target approximation
+"""
+
+import numpy as np
+from model.deepQN_v2.model import Model as ParentModel
+
+
+class Model(ParentModel):
+    def __init__(self, model_name, experiment_id, nb_state_features, nb_actions,
+                 train_config):
+        super(Model, self).__init__(
+            model_name, experiment_id, nb_state_features, nb_actions,
+            train_config)
+
+    def get_sarsa(self):
+
+        experience_index = np.random.choice(
+            range(len(self.experience_buffer)), self.params['batch_size'],
+            replace=False)
+
+        experiences = [self.experience_buffer.pop(index) for index in sorted(
+            experience_index, reverse=True)]
+
+        states, actions, rewards, next_states = zip(*experiences)
+        states = np.array(states)
+        actions = np.array(actions)
+        rewards = np.array(rewards)
+        next_states = np.array(next_states)
+
+        return states, actions, rewards, next_states


### PR DESCRIPTION
## Agent Summary
* minimum buffer size ~5000 for experience replay
* soft update of fixed target network after every training step
* action value approximation of estimated and expected are done on different networks.  